### PR TITLE
Modify evaluation interface to allow for more flexibility

### DIFF
--- a/oaz/cache/cache.hpp
+++ b/oaz/cache/cache.hpp
@@ -5,20 +5,20 @@
 
 #include "boost/multi_array.hpp"
 #include "oaz/games/game.hpp"
+#include "oaz/evaluator/evaluator.hpp"
+
 
 namespace oaz::cache {
 class Cache {
  public:
-  virtual bool Evaluate(const oaz::games::Game&, float*,
-                        boost::multi_array_ref<float, 1>) = 0;
-  virtual void Insert(const oaz::games::Game&, float,
-                      boost::multi_array_ref<float, 1>) = 0;
+  virtual bool Evaluate(const oaz::games::Game&,
+		  	std::unique_ptr<oaz::evaluator::Evaluation>*) = 0;
+  virtual void Insert(const oaz::games::Game&,
+                      std::unique_ptr<oaz::evaluator::Evaluation>*) = 0;
 
   virtual void BatchInsert(
       boost::multi_array_ref<oaz::games::Game*, 1>,
-      boost::multi_array_ref<float*, 1>,
-      boost::multi_array_ref<std::unique_ptr<boost::multi_array_ref<float, 1>>,
-                             1>,
+      boost::multi_array_ref<std::unique_ptr<oaz::evaluator::Evaluation>*, 1>,
       size_t) = 0;
 
   virtual ~Cache() = default;

--- a/oaz/evaluator/evaluator.hpp
+++ b/oaz/evaluator/evaluator.hpp
@@ -7,11 +7,25 @@
 
 namespace oaz::evaluator {
 
+class Evaluation {
+  public:
+    virtual float GetValue() const = 0;
+    virtual float GetPolicy(size_t) const = 0;
+
+    virtual std::unique_ptr<Evaluation> Clone() const = 0;
+
+    virtual ~Evaluation() {}
+    Evaluation() = default;
+    Evaluation(const Evaluation&) = default;
+    Evaluation(Evaluation&&) = default;
+    Evaluation& operator=(const Evaluation&) = default;
+    Evaluation& operator=(Evaluation&&) = default;
+
+};
+
 class Evaluator {
  public:
-  virtual void RequestEvaluation(oaz::games::Game*, float*,
-                                 boost::multi_array_ref<float, 1>,
-                                 oaz::thread_pool::Task*) = 0;
+  virtual void RequestEvaluation(oaz::games::Game*, std::unique_ptr<Evaluation>*, oaz::thread_pool::Task*) = 0;
 
   virtual ~Evaluator() {}
   Evaluator() = default;

--- a/oaz/mcts/search.hpp
+++ b/oaz/mcts/search.hpp
@@ -86,13 +86,11 @@ class Search {
   size_t GetNCompletions() const;
   size_t GetNActiveTasks() const;
   size_t GetEvaluatorIndex(size_t) const;
-  size_t GetPolicySize() const;
   bool Done() const;
 
   oaz::games::Game* GetGame(size_t);
   void ResetGame(size_t);
-  float& GetValue(size_t);
-  boost::multi_array_ref<float, 1> GetPolicy(size_t);
+  std::unique_ptr<oaz::evaluator::Evaluation>* GetEvaluation(size_t);
   SearchNode* GetNode(size_t);
 
   void SetNode(size_t, SearchNode*);
@@ -106,25 +104,22 @@ class Search {
   void HandleCreatedTask();
 
   void SelectNode(size_t);
-  void ExpandNode(SearchNode* node, oaz::games::Game*,
-                  boost::multi_array_ref<float, 1>);
+  void ExpandNode(SearchNode* node, oaz::games::Game*, oaz::evaluator::Evaluation*);
   static void BackpropagateNode(SearchNode*, float);
   void ExpandAndBackpropagateNode(size_t);
   void MaybeSelect(size_t);
   void Pause(size_t);
   void Unpause(SearchNode*);
 
-  void AddDirichletNoise(boost::multi_array_ref<float, 1>);
+  void AddDirichletNoise(boost::multi_array<float, 1>&);
   void PerformSearch();
 
   size_t m_batch_size;
-  size_t m_policy_size;
 
   std::vector<SearchNode*> m_nodes;
   std::vector<std::unique_ptr<oaz::games::Game>> m_games;
 
-  boost::multi_array<float, 1> m_values;
-  boost::multi_array<float, 2> m_policies;
+  boost::multi_array<std::unique_ptr<oaz::evaluator::Evaluation>, 1> m_evaluations;
 
   std::mt19937 m_generator;  // Check if thread safe
 

--- a/oaz/simulation/simulation_evaluator.cpp
+++ b/oaz/simulation/simulation_evaluator.cpp
@@ -1,14 +1,26 @@
 #include "oaz/simulation/simulation_evaluator.hpp"
 
+oaz::simulation::SimulationEvaluation::SimulationEvaluation(float value): m_value(value) {}
+
+float oaz::simulation::SimulationEvaluation::GetValue() const { return m_value; }
+
+float oaz::simulation::SimulationEvaluation::GetPolicy(size_t move) const { return 0.; }
+
+std::unique_ptr<oaz::evaluator::Evaluation> oaz::simulation::SimulationEvaluation::Clone() const {
+  return std::make_unique<SimulationEvaluation>(*this);
+}
+
 oaz::simulation::SimulationEvaluator::SimulationEvaluator(
     std::shared_ptr<oaz::thread_pool::ThreadPool> thread_pool)
     : m_thread_pool(std::move(thread_pool)) {}
 
 void oaz::simulation::SimulationEvaluator::RequestEvaluation(
-    oaz::games::Game* game, float* value,
-    boost::multi_array_ref<float, 1> policy, oaz::thread_pool::Task* task) {
+    oaz::games::Game* game,
+    std::unique_ptr<oaz::evaluator::Evaluation>* evaluation,
+    oaz::thread_pool::Task* task) {
+  std::vector<size_t> available_moves;
   std::unique_ptr<oaz::games::Game> game_copy = game->Clone();
-  *value = Simulate(game_copy.get());
+  *evaluation = std::move(std::make_unique<SimulationEvaluation>(Simulate(game_copy.get())));
   m_thread_pool->enqueue(task);
 }
 

--- a/oaz/simulation/simulation_evaluator.hpp
+++ b/oaz/simulation/simulation_evaluator.hpp
@@ -11,11 +11,24 @@
 
 namespace oaz::simulation {
 
+class SimulationEvaluation : public oaz::evaluator::Evaluation {
+  public:
+    SimulationEvaluation() = default;
+    SimulationEvaluation(float);
+    float GetValue() const;
+    float GetPolicy(size_t) const;
+
+    std::unique_ptr<Evaluation> Clone() const;
+
+  private:
+    float m_value;
+};
+
 class SimulationEvaluator : public oaz::evaluator::Evaluator {
  public:
   explicit SimulationEvaluator(std::shared_ptr<oaz::thread_pool::ThreadPool>);
-  void RequestEvaluation(oaz::games::Game* game, float* value,
-                         boost::multi_array_ref<float, 1> policy,
+  void RequestEvaluation(oaz::games::Game* game,
+		  	 std::unique_ptr<oaz::evaluator::Evaluation>* evaluation,
                          oaz::thread_pool::Task* task) override;
 
  private:

--- a/test/simulation/simulation_evaluator_test.cpp
+++ b/test/simulation/simulation_evaluator_test.cpp
@@ -20,12 +20,11 @@ TEST(RequestEvaluation, Default) {
   auto pool = make_shared<oaz::thread_pool::ThreadPool>(1);
   auto evaluator = make_shared<oaz::simulation::SimulationEvaluator>(pool);
   oaz::games::ConnectFour game;
-  boost::multi_array<float, 1> policy(boost::extents[7]);
-  float value;
+  std::unique_ptr<oaz::evaluator::Evaluation> evaluation(std::make_unique<oaz::simulation::SimulationEvaluation>());
 
   oaz::thread_pool::DummyTask task(1);
 
-  evaluator->RequestEvaluation(&game, &value, policy, &task);
+  evaluator->RequestEvaluation(&game, &evaluation, &task);
 
   task.wait();
 }
@@ -49,11 +48,11 @@ void EvaluateGames(
     size_t len = index % (moves.size() + 1);
 
     game.PlayFromString(moves.substr(0, len));
+  
+    std::unique_ptr<oaz::evaluator::Evaluation> evaluation(std::make_unique<oaz::simulation::SimulationEvaluation>());
 
-    boost::multi_array<float, 1> policy(boost::extents[7]);
-    float value;
 
-    evaluator->RequestEvaluation(&game, &value, policy, task);
+    evaluator->RequestEvaluation(&game, &evaluation, task);
 
     indices_q->Lock();
   }


### PR DESCRIPTION
For example, an evaluated policy need no longer be stored as an
array.